### PR TITLE
Fix handling of missing package resource directory

### DIFF
--- a/flask_registry/__init__.py
+++ b/flask_registry/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Flask-Registry
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2013, 2014 CERN.
 ##
 ## Flask-Registry is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -232,7 +232,7 @@ class RegistryProxy(LocalProxy):
         initialization.
     """
 
-    # pylint: disable=W0142, C0111
+    # pylint: disable=W0142, C0111, E1002
     def __init__(self, namespace, registry_class, *args, **kwargs):
         def _lookup():
             if not 'registry' in getattr(current_app, 'extensions', {}):

--- a/flask_registry/registries/pkgresources.py
+++ b/flask_registry/registries/pkgresources.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Flask-Registry
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2013, 2014 CERN.
 ##
 ## Flask-Registry is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -94,7 +94,7 @@ from __future__ import absolute_import
 
 import os
 from werkzeug.utils import import_string
-from pkg_resources import iter_entry_points, resource_listdir
+from pkg_resources import iter_entry_points, resource_listdir, resource_isdir
 
 from .core import DictRegistry
 from .modulediscovery import ModuleAutoDiscoveryRegistry
@@ -142,8 +142,9 @@ class PkgResourcesDirDiscoveryRegistry(ModuleAutoDiscoveryRegistry):
         """
         Load list of files from resource directory.
         """
-        for filename in resource_listdir(pkg, self.module_name):
-            self.register(os.path.join(
-                os.path.dirname(import_string(pkg).__file__),
-                self.module_name, filename)
-            )
+        if resource_isdir(pkg, self.module_name):
+            for filename in resource_listdir(pkg, self.module_name):
+                self.register(os.path.join(
+                    os.path.dirname(import_string(pkg).__file__),
+                    self.module_name, filename)
+                )

--- a/tests/test_pkgresources.py
+++ b/tests/test_pkgresources.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##
 ## This file is part of Flask-Registry
-## Copyright (C) 2013 CERN.
+## Copyright (C) 2013, 2014 CERN.
 ##
 ## Flask-Registry is free software; you can redistribute it and/or
 ## modify it under the terms of the GNU General Public License as
@@ -43,6 +43,21 @@ class TestPkgResourcesDiscoveryRegistry(FlaskTestCase):
             )
 
         assert len(self.app.extensions['registry']['myns']) == 1
+
+    def test_missing_folder(self):
+        Registry(app=self.app)
+
+        self.app.extensions['registry']['pathns'] = \
+            ImportPathRegistry(initial=['tests'])
+
+        self.app.extensions['registry']['myns'] = \
+            PkgResourcesDirDiscoveryRegistry(
+                'non_existing_folder',
+                app=self.app,
+                registry_namespace='pathns',
+            )
+
+        assert len(self.app.extensions['registry']['myns']) == 0
 
 
 class TestEntryPointRegistry(FlaskTestCase):


### PR DESCRIPTION
- Fixes PkgResourcesDirDiscoveryRegistry to properly handle
  missing resource directories.

Reported-by: Javier Martin Montull javier.martin.montull@cern.ch
Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
