### PR TITLE
Add singleton registry

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,6 +25,9 @@ API Docs
 .. autoclass:: DictRegistry
    :members:
 
+.. autoclass:: SingletonRegistry
+   :members:
+
 .. autoclass:: ImportPathRegistry
    :members:
 

--- a/flask_registry/__init__.py
+++ b/flask_registry/__init__.py
@@ -254,7 +254,7 @@ from .version import __version__
 # API of registries
 #
 from .registries.core import ListRegistry, DictRegistry, \
-    ImportPathRegistry, ModuleRegistry
+    ImportPathRegistry, ModuleRegistry, SingletonRegistry
 from .registries.modulediscovery import \
     ModuleDiscoveryRegistry, ModuleAutoDiscoveryRegistry
 from .registries.pkgresources import EntryPointRegistry, \
@@ -268,5 +268,5 @@ __all__ = [
     'ModuleDiscoveryRegistry', 'ModuleAutoDiscoveryRegistry',
     'EntryPointRegistry', 'PkgResourcesDirDiscoveryRegistry',
     'PackageRegistry', 'ExtensionRegistry', 'ConfigurationRegistry',
-    'BlueprintAutoDiscoveryRegistry', '__version__'
+    'BlueprintAutoDiscoveryRegistry', 'SingletonRegistry', '__version__'
 ]

--- a/flask_registry/registries/core.py
+++ b/flask_registry/registries/core.py
@@ -22,7 +22,7 @@
 ## or submit itself to any jurisdiction.
 
 """
-Core registries
+Core Registries
 ===============
 
 The core registries are useful to use as subclasses for other more
@@ -103,6 +103,7 @@ class ListRegistry(RegistryBase):
         """
         self.registry.remove(item)
 
+
 class DictRegistry(RegistryBase):
     """
     Basic registry that just keeps a key, value pairs. Provides normal
@@ -171,6 +172,58 @@ class DictRegistry(RegistryBase):
         :param item: Object to register
         """
         return self.registry.items()
+
+
+class SingletonRegistry(RegistryBase):
+    """
+    Basic registry that just keeps a single object.
+
+    >>> from flask_registry import SingletonRegistry
+    >>> app = Flask('myapp')
+    >>> r = Registry(app=app)
+    >>> r['singleton'] = SingletonRegistry()
+    >>> r['singleton'].register("test string")
+    >>> r['singleton'].get()
+    'test string'
+    >>> r['singleton'].register("another string")
+    Traceback (most recent call last):
+        ...
+    RegistryError: Object already registered.
+    >>> r['singleton'].unregister()
+    >>> r['singleton'].get() is None
+    True
+    >>> r['singleton'].unregister()
+    Traceback (most recent call last):
+        ...
+    RegistryError: No object to unregister.
+    """
+
+    def __init__(self):
+        self._singlton = None
+
+    def register(self, obj):
+        """
+        Register a new singleton object
+
+        :param obj: The object to register
+        """
+        if self._singlton is not None:
+            raise RegistryError("Object already registered.")
+        self._singlton = obj
+
+    def unregister(self):
+        """
+        Unregister the singleton object
+        """
+        if self._singlton is None:
+            raise RegistryError("No object to unregister.")
+        self._singlton = None
+
+    def get(self):
+        """
+        Get the registered object
+        """
+        return self._singlton
 
 
 # pylint: disable=R0921

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,7 +27,8 @@ import six
 
 from .helpers import FlaskTestCase, MockModule
 from flask.ext.registry import Registry, RegistryError, \
-    ListRegistry, DictRegistry, ImportPathRegistry, ModuleRegistry
+    ListRegistry, DictRegistry, ImportPathRegistry, ModuleRegistry, \
+    SingletonRegistry
 
 
 class TestListRegistry(FlaskTestCase):
@@ -76,6 +77,28 @@ class TestDictRegistry(FlaskTestCase):
 
         del self.app.extensions['registry']['myns']['key1']
         assert len(self.app.extensions['registry']['myns']) == 0
+
+
+class TestSingletonRegistry(FlaskTestCase):
+    def test_registration(self):
+        Registry(app=self.app)
+        self.app.extensions['registry']['myns'] = SingletonRegistry()
+        self.app.extensions['registry']['myns'].register('item1')
+        assert self.app.extensions['registry']['myns'].get() == 'item1'
+
+        self.assertRaises(
+            RegistryError,
+            self.app.extensions['registry']['myns'].register,
+            'item 2'
+        )
+
+        self.app.extensions['registry']['myns'].unregister()
+        assert self.app.extensions['registry']['myns'].get() is None
+
+        self.assertRaises(
+            RegistryError,
+            self.app.extensions['registry']['myns'].unregister,
+        )
 
 
 class TestImportPathRegistry(FlaskTestCase):


### PR DESCRIPTION
- Adds SingletonRegistry for ensuring only a single
  object is registered at a given point.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
