### PR TITLE
Exclude option for ImportPathRegistry

### DIFF
--- a/flask_registry/registries/appdiscovery.py
+++ b/flask_registry/registries/appdiscovery.py
@@ -183,7 +183,8 @@ class PackageRegistry(ImportPathRegistry):
     """
     def __init__(self, app):
         super(PackageRegistry, self).__init__(
-            initial=app.config.get('PACKAGES', [])
+            initial=app.config.get('PACKAGES', []),
+            exclude=app.config.get('PACKAGES_EXCLUDE', [])
         )
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -135,6 +135,16 @@ class TestImportPathRegistry(FlaskTestCase):
             self.app.extensions['registry']['impns'][0], six.string_types
         )
 
+    def test_exclude(self):
+        Registry(app=self.app)
+        self.app.extensions['registry']['impns'] = ImportPathRegistry(
+            initial=['flask_registry.registries.*'],
+            exclude=['flask_registry.registries.pkgresources'],
+        )
+        assert len(self.app.extensions['registry']['impns']) == 3
+        assert 'flask_registry.registries.pkgresources' not in \
+            self.app.extensions['registry']['impns']
+
     def test_unregister(self):
         Registry(app=self.app)
         self.app.extensions['registry']['impns'] = ImportPathRegistry(


### PR DESCRIPTION
- Adds option to specify a list of import paths to exclude
  from an ImportPathRegistry.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch`
