### PR TITLE
Using the collections abstract classes for list and dict.

### DIFF
--- a/flask_registry/__init__.py
+++ b/flask_registry/__init__.py
@@ -21,263 +21,54 @@
 ## granted to it by virtue of its status as an Intergovernmental Organization
 ## or submit itself to any jurisdiction.
 
-"""
-Flask extension
-===============
+"""Flask extension.
 
 Flask-Registry is initialized like this:
 
->>> from flask import Flask
->>> from flask_registry import Registry, ListRegistry
->>> app = Flask('myapp')
->>> r = Registry(app=app)
+.. code-block:: pycon
+
+    >>> from flask import Flask
+    >>> from flask_registry import Registry, ListRegistry
+    >>> app = Flask('myapp')
+    >>> r = Registry(app=app)
 
 A simple usage example of ``ListRegistry`` looks like this:
 
->>> app.extensions['registry']['my.namespace'] = ListRegistry()
->>> len(app.extensions['registry'])
-1
->>> app.extensions['registry']['my.namespace'].register("something")
->>> app.extensions['registry']['my.namespace'].register("something else")
->>> len(app.extensions['registry']['my.namespace'])
-2
->>> for obj in app.extensions['registry']['my.namespace']:
-...     print(obj)
-something
-something else
+.. code-block:: pycon
+
+    >>> app.extensions['registry']['my.namespace'] = ListRegistry()
+    >>> len(app.extensions['registry'])
+    1
+    >>> app.extensions['registry']['my.namespace'].register("something")
+    >>> app.extensions['registry']['my.namespace'].register("something else")
+    >>> len(app.extensions['registry']['my.namespace'])
+    2
+    >>> for obj in app.extensions['registry']['my.namespace']:
+    ...     print(obj)
+    something
+    something else
 """
 
-from __future__ import absolute_import
+from .base import Registry, RegistryError, RegistryProxy, RegistryBase
+from .registries.core import (ListRegistry, DictRegistry,
+                              ImportPathRegistry, ModuleRegistry,
+                              SingletonRegistry)
+from .registries.modulediscovery import (ModuleDiscoveryRegistry,
+                                         ModuleAutoDiscoveryRegistry)
+from .registries.pkgresources import (EntryPointRegistry,
+                                      PkgResourcesDirDiscoveryRegistry)
+from .registries.appdiscovery import (PackageRegistry,
+                                      ExtensionRegistry,
+                                      ConfigurationRegistry,
+                                      BlueprintAutoDiscoveryRegistry)
 
-from werkzeug.local import LocalProxy
-from flask import current_app
-
-try:
-    from collections import MutableMapping
-except ImportError:
-    from collection.abc import MutableMapping
-
-
-class RegistryError(Exception):
-    """
-    Exception class raised for user errors (e.g. creating two registries in
-    the same namespace)
-    """
-    pass
-
-
-class Registry(MutableMapping):
-    """
-    Flask extension
-
-    Initialization of the extension:
-
-    >>> from flask import Flask
-    >>> from flask_registry import Registry
-    >>> app = Flask('myapp')
-    >>> r = Registry(app)
-    >>> app.extensions['registry']
-    <Registry ()>
-
-    or alternatively using the factory pattern:
-
-    >>> app = Flask('myapp')
-    >>> r = Registry()
-    >>> r.init_app(app)
-    >>> r
-    <Registry ()>
-
-    """
-
-    def __init__(self, app=None):
-        """
-        Initialize the Registry.
-
-        :param app: Flask application
-        :type app: flask.Flask
-        """
-        super(MutableMapping, self).__init__()
-        self._registry = {}
-        self.app = app
-        if app is not None:
-            self.init_app(app)
-
-    def init_app(self, app):
-        """
-        Initialize a Flask application.
-
-        Only one Registry per application is allowed.
-
-        :param app: Flask application
-        :type app: flask.Flask
-        :raise RegistryError: if the registry is already initialized
-        """
-        # Follow the Flask guidelines on usage of app.extensions
-        if not hasattr(app, 'extensions'):
-            app.extensions = {}
-        if 'registry' in app.extensions:
-            raise RegistryError("Flask application already initialized")
-        app.extensions['registry'] = self
-
-    def __iter__(self):
-        """Get iterator over registries."""
-        return iter(self._registry)
-
-    def __len__(self):
-        """Get length of registries."""
-        return len(self._registry)
-
-    def __getitem__(self, key):
-        """
-        Get a registry with a given namespace.
-
-        :param key: Namespace
-        """
-        return self._registry[key]
-
-    def __delitem__(self, key):
-        """
-        Remove a registry
-
-        :param key: Namespace
-        """
-        self._registry[key].namespace = None
-        del self._registry[key]
-
-    def __setitem__(self, key, value):
-        """
-        Register a registry in the Flask application registry.
-
-        :param key: Namespace
-        :param value: Instance of RegistryBase or subclass
-        :raise RegistryError: if the key is already present
-        """
-        if key in self._registry:
-            raise RegistryError("Namespace %s already taken." % key)
-        value.namespace = key
-        self._registry[key] = value
-
-    def __repr__(self):
-        """Get the string representation."""
-        return "<{0} ({1})>".format(self.__class__.__name__,
-                                    ", ".join(self._registry.keys()))
-
-
-# pylint: disable=R0921
-class RegistryBase(object):
-    """
-    Abstract base class for all registries.
-
-    Each subclass must implement the ``register()`` method.
-    Each subclass may implement the ``unregister()`` method.
-
-    Once a registry is registered in the Flask application, the namespace
-    under which it is available is injected into it self.
-
-    Please see ``flask_registry.registries.core`` for simple examples of
-    subclasses.
-    """
-    _namespace = None
-
-    @property
-    def namespace(self):
-        """
-        Namespace. Used only by the Flask extension to inject the namespace
-        under which this instance is registered in the Flask application.
-        Defaults to ``None`` if not registered in a Flask application.
-        """
-        return self._namespace
-
-    @namespace.setter
-    def namespace(self, value):
-        """ Setter for namespace property. """
-        if self._namespace and value is not None:
-            raise RegistryError("Namespace cannot be changed.")
-        self._namespace = value
-
-    def register(self, *args, **kwargs):
-        """
-        Abstract method which MUST be overwritten by subclasses. A subclass
-        does not need to take the same number of arguments as the abstract
-        base class.
-        """
-        raise NotImplementedError()
-
-    def unregister(self, *args, **kwargs):
-        """
-        Abstract method which MAY be overwritten by subclasses. A subclass
-        does not need to take the same number of arguments as the abstract
-        base class.
-        """
-        raise NotImplementedError()
-
-
-class RegistryProxy(LocalProxy):
-    """
-    Lazy proxy object to a registry in the ``current_app``
-
-    Allows you to define a registry in your local module without needing to
-    initialize it first. Once accessed the first time, the registry will be
-    initialized in the current_app, thus you must be working in either
-    the Flask application context or request context.
-
-    >>> from flask import Flask
-    >>> app = Flask('myapp')
-    >>> from flask_registry import Registry, RegistryProxy, RegistryBase
-    >>> r = Registry(app=app)
-    >>> proxy = RegistryProxy('myns', RegistryBase)
-    >>> 'myns' in app.extensions['registry']
-    False
-    >>> with app.app_context():
-    ...     print(proxy.namespace)
-    ...
-    myns
-    >>> 'myns' in app.extensions['registry']
-    True
-
-    :param namespace: Namespace for registry
-    :param registry_class: The registry class - i.e. a sublcass of
-        ``RegistryBase``.
-    :param args: Arguments passed to ``registry_class`` on initialization.
-    :param kwargs: Keyword arguments passed to ``registry_class`` on
-        initialization.
-    """
-
-    # pylint: disable=W0142, C0111, E1002
-    def __init__(self, namespace, registry_class, *args, **kwargs):
-        def _lookup():
-            if not 'registry' in getattr(current_app, 'extensions', {}):
-                raise RegistryError('Registry is not initialized.')
-            if namespace not in current_app.extensions['registry']:
-                # pylint: disable=W0142
-                current_app.extensions['registry'][namespace] = \
-                    registry_class(
-                        *args, **kwargs
-                    )
-            return current_app.extensions['registry'][namespace]
-        super(RegistryProxy, self).__init__(_lookup)
-
-
-# Version information
 from .version import __version__
 
-#
-# API of registries
-#
-from .registries.core import ListRegistry, DictRegistry, \
-    ImportPathRegistry, ModuleRegistry, SingletonRegistry
-from .registries.modulediscovery import \
-    ModuleDiscoveryRegistry, ModuleAutoDiscoveryRegistry
-from .registries.pkgresources import EntryPointRegistry, \
-    PkgResourcesDirDiscoveryRegistry
-from .registries.appdiscovery import PackageRegistry, \
-    ExtensionRegistry, ConfigurationRegistry, BlueprintAutoDiscoveryRegistry
-
-__all__ = [
+__all__ = (
     'Registry', 'RegistryError', 'RegistryProxy', 'RegistryBase',
     'ListRegistry', 'DictRegistry', 'ImportPathRegistry', 'ModuleRegistry',
     'ModuleDiscoveryRegistry', 'ModuleAutoDiscoveryRegistry',
     'EntryPointRegistry', 'PkgResourcesDirDiscoveryRegistry',
     'PackageRegistry', 'ExtensionRegistry', 'ConfigurationRegistry',
     'BlueprintAutoDiscoveryRegistry', 'SingletonRegistry', '__version__'
-]
+)

--- a/flask_registry/base.py
+++ b/flask_registry/base.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+##
+## This file is part of Flask-Registry
+## Copyright (C) 2013, 2014 CERN.
+##
+## Flask-Registry is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 2 of the
+## License, or (at your option) any later version.
+##
+## Flask-Registry is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Flask-Registry; if not, write to the Free Software Foundation,
+## Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+##
+## In applying this licence, CERN does not waive the privileges and immunities
+## granted to it by virtue of its status as an Intergovernmental Organization
+## or submit itself to any jurisdiction.
+
+"""Registry base module."""
+
+from __future__ import absolute_import, unicode_literals
+
+from flask import current_app
+from werkzeug.local import LocalProxy
+
+try:
+    from collections import MutableMapping
+except ImportError:
+    from collection.abc import MutableMapping
+
+
+class RegistryError(Exception):
+
+    """
+    Exception class raised for user errors.
+
+    e.g. creating two registries in the same namespace)
+    """
+
+
+class Registry(MutableMapping):
+
+    """
+    Flask extension.
+
+    Initialization of the extension:
+
+    >>> from flask import Flask
+    >>> from flask_registry import Registry
+    >>> app = Flask('myapp')
+    >>> r = Registry(app)
+    >>> app.extensions['registry']
+    <Registry ()>
+
+    or alternatively using the factory pattern:
+
+    >>> app = Flask('myapp')
+    >>> r = Registry()
+    >>> r.init_app(app)
+    >>> r
+    <Registry ()>
+
+    """
+
+    def __init__(self, app=None):
+        """
+        Initialize the Registry.
+
+        :param app: Flask application
+        :type app: flask.Flask
+        """
+        super(MutableMapping, self).__init__()
+        self._registry = {}
+        self.app = app
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """
+        Initialize a Flask application.
+
+        Only one Registry per application is allowed.
+
+        :param app: Flask application
+        :type app: flask.Flask
+        :raise RegistryError: if the registry is already initialized
+        """
+        # Follow the Flask guidelines on usage of app.extensions
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        if 'registry' in app.extensions:
+            raise RegistryError("Flask application already initialized")
+        app.extensions['registry'] = self
+
+    def __iter__(self):
+        """Get iterator over registries."""
+        return iter(self._registry)
+
+    def __len__(self):
+        """Get length of registries."""
+        return len(self._registry)
+
+    def __getitem__(self, key):
+        """
+        Get a registry with a given namespace.
+
+        :param key: Namespace
+        """
+        return self._registry[key]
+
+    def __delitem__(self, key):
+        """
+        Remove a registry
+
+        :param key: Namespace
+        """
+        self._registry[key].namespace = None
+        del self._registry[key]
+
+    def __setitem__(self, key, value):
+        """
+        Register a registry in the Flask application registry.
+
+        :param key: Namespace
+        :param value: Instance of RegistryBase or subclass
+        :raise RegistryError: if the key is already present
+        """
+        if key in self._registry:
+            raise RegistryError("Namespace %s already taken." % key)
+        value.namespace = key
+        self._registry[key] = value
+
+    def __repr__(self):
+        """Get the string representation."""
+        return "<{0} ({1})>".format(self.__class__.__name__,
+                                    ", ".join(self._registry.keys()))
+
+
+# pylint: disable=R0921
+class RegistryBase(object):
+    """
+    Abstract base class for all registries.
+
+    Each subclass must implement the ``register()`` method.
+    Each subclass may implement the ``unregister()`` method.
+
+    Once a registry is registered in the Flask application, the namespace
+    under which it is available is injected into it self.
+
+    Please see ``flask_registry.registries.core`` for simple examples of
+    subclasses.
+    """
+    _namespace = None
+
+    @property
+    def namespace(self):
+        """
+        Namespace. Used only by the Flask extension to inject the namespace
+        under which this instance is registered in the Flask application.
+        Defaults to ``None`` if not registered in a Flask application.
+        """
+        return self._namespace
+
+    @namespace.setter
+    def namespace(self, value):
+        """ Setter for namespace property. """
+        if self._namespace and value is not None:
+            raise RegistryError("Namespace cannot be changed.")
+        self._namespace = value
+
+    def register(self, *args, **kwargs):
+        """
+        Abstract method which MUST be overwritten by subclasses. A subclass
+        does not need to take the same number of arguments as the abstract
+        base class.
+        """
+        raise NotImplementedError()
+
+    def unregister(self, *args, **kwargs):
+        """
+        Abstract method which MAY be overwritten by subclasses. A subclass
+        does not need to take the same number of arguments as the abstract
+        base class.
+        """
+        raise NotImplementedError()
+
+
+class RegistryProxy(LocalProxy):
+    """
+    Lazy proxy object to a registry in the ``current_app``
+
+    Allows you to define a registry in your local module without needing to
+    initialize it first. Once accessed the first time, the registry will be
+    initialized in the current_app, thus you must be working in either
+    the Flask application context or request context.
+
+    >>> from flask import Flask
+    >>> app = Flask('myapp')
+    >>> from flask_registry import Registry, RegistryProxy, RegistryBase
+    >>> r = Registry(app=app)
+    >>> proxy = RegistryProxy('myns', RegistryBase)
+    >>> 'myns' in app.extensions['registry']
+    False
+    >>> with app.app_context():
+    ...     print(proxy.namespace)
+    ...
+    myns
+    >>> 'myns' in app.extensions['registry']
+    True
+
+    :param namespace: Namespace for registry
+    :param registry_class: The registry class - i.e. a sublcass of
+        ``RegistryBase``.
+    :param args: Arguments passed to ``registry_class`` on initialization.
+    :param kwargs: Keyword arguments passed to ``registry_class`` on
+        initialization.
+    """
+
+    # pylint: disable=W0142, C0111, E1002
+    def __init__(self, namespace, registry_class, *args, **kwargs):
+        def _lookup():
+            if 'registry' not in getattr(current_app, 'extensions', {}):
+                raise RegistryError('Registry is not initialized.')
+            if namespace not in current_app.extensions['registry']:
+                # pylint: disable=W0142
+                current_app.extensions['registry'].update(
+                    {namespace: registry_class(*args, **kwargs)}
+                )
+            return current_app.extensions['registry'][namespace]
+        super(RegistryProxy, self).__init__(_lookup)

--- a/flask_registry/registries/core.py
+++ b/flask_registry/registries/core.py
@@ -34,13 +34,13 @@ registries.
 from __future__ import absolute_import
 
 from werkzeug.utils import find_modules, import_string
-from flask_registry import RegistryBase, RegistryError
 
 try:
     from collections import Sequence, MutableMapping
 except ImportError:
     from collections.abs import Sequence, MutableMapping
 
+from ..base import RegistryBase, RegistryError
 
 
 class ListRegistry(RegistryBase, Sequence):

--- a/flask_registry/registries/modulediscovery.py
+++ b/flask_registry/registries/modulediscovery.py
@@ -87,7 +87,7 @@ from werkzeug.utils import find_modules, import_string
 from werkzeug._compat import reraise
 from flask import current_app, has_app_context
 
-from flask_registry import RegistryProxy, RegistryBase, RegistryError
+from ..base import RegistryProxy, RegistryBase, RegistryError
 from .core import ModuleRegistry
 
 

--- a/tests/syntaxerror_module.py
+++ b/tests/syntaxerror_module.py
@@ -21,5 +21,6 @@
 ## granted to it by virtue of its status as an Intergovernmental Organization
 ## or submit itself to any jurisdiction.
 
+
 def func_with_syntax_error()
     pass

--- a/tests/syntaxerror_views.py
+++ b/tests/syntaxerror_views.py
@@ -21,11 +21,10 @@
 ## granted to it by virtue of its status as an Intergovernmental Organization
 ## or submit itself to any jurisdiction.
 
-"""
-Test file for BlueprintAutoDiscoverRegistry testing of syntax errors.
-"""
+"""Test file for BlueprintAutoDiscoverRegistry testing of syntax errors."""
 
 from flask import Blueprint
+
 
 # SYNTAX ERROR IS ON PURPOSE
 blueprint = Blueprint('test', __name__

--- a/tests/test_appdiscovery.py
+++ b/tests/test_appdiscovery.py
@@ -24,11 +24,13 @@
 from __future__ import absolute_import
 
 from .helpers import FlaskTestCase
-from flask_registry import Registry, ExtensionRegistry, PackageRegistry, \
-    ConfigurationRegistry, ImportPathRegistry, BlueprintAutoDiscoveryRegistry
+from flask_registry import (Registry, ExtensionRegistry, PackageRegistry,
+                            ConfigurationRegistry, ImportPathRegistry,
+                            BlueprintAutoDiscoveryRegistry)
 
 
 class TestExtensionRegistry(FlaskTestCase):
+
     def test_registration(self):
         Registry(app=self.app)
 
@@ -43,8 +45,7 @@ class TestExtensionRegistry(FlaskTestCase):
 
         self.assertRaises(
             NotImplementedError,
-            self.app.extensions['registry']['extensions'].unregister
-        )
+            self.app.extensions['registry']['extensions'].unregister)
 
 
 class TestPackageRegistry(FlaskTestCase):
@@ -133,10 +134,11 @@ class TestBlueprintAutoDiscoveryRegistry(FlaskTestCase):
             module_name='syntaxerror_views'
         )
 
-        self.app.extensions['registry']['blueprints'] = \
-            BlueprintAutoDiscoveryRegistry(
-                app=self.app, module_name='syntaxerror_views', silent=True
-            )
+        self.app.extensions['registry'].update(
+            blueprints=BlueprintAutoDiscoveryRegistry(
+                app=self.app,
+                module_name='syntaxerror_views',
+                silent=True))
 
         self.assertEqual(
             len(self.app.extensions['registry']['blueprints']),

--- a/tests/test_modulediscovery.py
+++ b/tests/test_modulediscovery.py
@@ -33,16 +33,16 @@ class TestModuleDiscoveryRegistry(FlaskTestCase):
     def test_registration(self):
         Registry(app=self.app)
 
-        self.app.extensions['registry']['pathns'] = \
-            ImportPathRegistry(initial=['flask_registry.*'])
+        self.app.extensions['registry'].update(
+            pathns=ImportPathRegistry(initial=['flask_registry.*'])
+        )
 
-        assert len(self.app.extensions['registry']['pathns']) == 2
+        self.assertEquals(3, len(self.app.extensions['registry']['pathns']))
 
         self.app.extensions['registry']['myns'] = \
             ModuleDiscoveryRegistry(
                 'appdiscovery',
-                registry_namespace='pathns'
-            )
+                registry_namespace='pathns')
 
         with self.app.app_context():
             self.app.extensions['registry']['myns'].discover()
@@ -72,14 +72,11 @@ class TestModuleDiscoveryRegistry(FlaskTestCase):
             'flask_registry.registries',
         ]
 
-        self.app.extensions['registry']['path.ns'] = \
-            ImportPathRegistry(initial=['flask_registry.*'])
-
-        self.app.extensions['registry']['myns'] = \
-            ModuleDiscoveryRegistry(
-                'appdiscovery',
-                registry_namespace='path.ns'
-            )
+        self.app.extensions['registry'].update({
+            'path.ns': ImportPathRegistry(initial=['flask_registry.*']),
+            'myns': ModuleDiscoveryRegistry('appdiscovery',
+                                            registry_namespace='path.ns')
+        })
 
         with self.app.app_context():
             self.app.extensions['registry']['myns'].discover()
@@ -88,14 +85,10 @@ class TestModuleDiscoveryRegistry(FlaskTestCase):
     def test_missing_module(self):
         Registry(app=self.app)
 
-        self.app.extensions['registry']['pathns'] = \
-            ImportPathRegistry(initial=['flask_registry.*'])
-
-        self.app.extensions['registry']['myns'] = \
-            ModuleDiscoveryRegistry(
-                'some_non_existing_module',
-                registry_namespace='pathns'
-            )
+        self.app.extensions['registry'].update(
+            pathns=ImportPathRegistry(initial=['flask_registry.*']),
+            myns=ModuleDiscoveryRegistry('some_non_existing_module',
+                                         registry_namespace='pathns'))
 
         with self.app.app_context():
             self.app.extensions['registry']['myns'].discover()
@@ -104,33 +97,23 @@ class TestModuleDiscoveryRegistry(FlaskTestCase):
     def test_broken_module(self):
         Registry(app=self.app)
 
-        self.app.extensions['registry']['pathns'] = \
-            ImportPathRegistry(initial=['tests'])
-
-        self.app.extensions['registry']['myns'] = \
-            ModuleDiscoveryRegistry(
-                'broken_module',
-                registry_namespace='pathns'
-            )
+        self.app.extensions['registry'].update(
+            pathns=ImportPathRegistry(initial=['tests']),
+            myns=ModuleDiscoveryRegistry('broken_module',
+                                         registry_namespace='pathns'))
 
         with self.app.app_context():
-            self.assertRaises(
-                ImportError,
-                self.app.extensions['registry']['myns'].discover
-            )
+            self.assertRaises(ImportError,
+                              self.app.extensions['registry']['myns'].discover)
             assert len(self.app.extensions['registry']['myns']) == 0
 
     def test_syntaxerror_module(self):
         Registry(app=self.app)
 
-        self.app.extensions['registry']['pathns'] = \
-            ImportPathRegistry(initial=['tests'])
-
-        self.app.extensions['registry']['myns'] = \
-            ModuleDiscoveryRegistry(
-                'syntaxerror_module',
-                registry_namespace='pathns',
-            )
+        self.app.extensions['registry'].update(
+            pathns=ImportPathRegistry(initial=['tests']),
+            myns=ModuleDiscoveryRegistry('syntaxerror_module',
+                                         registry_namespace='pathns'))
 
         with self.app.app_context():
             self.assertRaises(
@@ -141,11 +124,9 @@ class TestModuleDiscoveryRegistry(FlaskTestCase):
 
         # Silence the error
         self.app.extensions['registry']['myns_silent'] = \
-            ModuleDiscoveryRegistry(
-                'syntaxerror_module',
-                registry_namespace='pathns',
-                silent=True,
-            )
+            ModuleDiscoveryRegistry('syntaxerror_module',
+                                    registry_namespace='pathns',
+                                    silent=True)
 
         with self.app.app_context():
             self.app.extensions['registry']['myns_silent'].discover()
@@ -159,10 +140,8 @@ class TestModuleDiscoveryRegistry(FlaskTestCase):
         self.app.extensions['registry']['pathns'].register(registries)
 
         self.app.extensions['registry']['myns'] = \
-            ModuleDiscoveryRegistry(
-                'appdiscovery',
-                registry_namespace='pathns'
-            )
+            ModuleDiscoveryRegistry('appdiscovery',
+                                    registry_namespace='pathns')
 
         with self.app.app_context():
             self.app.extensions['registry']['myns'].discover()
@@ -183,13 +162,11 @@ class TestModuleDiscoveryRegistry(FlaskTestCase):
             assert 'pathns' not in self.app.extensions['registry']
 
             self.app.extensions['registry']['myns'] = \
-                ModuleDiscoveryRegistry(
-                    'appdiscovery',
-                    registry_namespace=proxy
-                )
+                ModuleDiscoveryRegistry('appdiscovery',
+                                        registry_namespace=proxy)
 
             assert 'pathns' in self.app.extensions['registry']
-            assert len(self.app.extensions['registry']['pathns']) == 2
+            self.assertEqual(3, len(self.app.extensions['registry']['pathns']))
 
             self.app.extensions['registry']['myns'].discover()
 
@@ -205,14 +182,12 @@ class TestModuleAutoDiscoveryRegistry(FlaskTestCase):
         self.app.extensions['registry']['pathns'] = \
             ImportPathRegistry(initial=['flask_registry.*'])
 
-        assert len(self.app.extensions['registry']['pathns']) == 2
+        self.assertEqual(3, len(self.app.extensions['registry']['pathns']))
 
         self.app.extensions['registry']['myns'] = \
-            ModuleAutoDiscoveryRegistry(
-                'appdiscovery',
-                app=self.app,
-                registry_namespace='pathns'
-            )
+            ModuleAutoDiscoveryRegistry('appdiscovery',
+                                        app=self.app,
+                                        registry_namespace='pathns')
 
         assert len(self.app.extensions['registry']['myns']) == 1
         from flask_registry.registries import appdiscovery
@@ -230,9 +205,7 @@ class TestModuleAutoDiscoveryRegistry(FlaskTestCase):
         )
 
         with self.app.app_context():
-            assert len(self.app.extensions['registry']['pathns']) == 2
-            assert len(list(myns)) == 1
+            self.assertEqual(3, len(self.app.extensions['registry']['pathns']))
+            self.assertEqual(1, len(list(myns)))
             from flask_registry.registries import appdiscovery
-            assert myns[0] == appdiscovery
-
-
+            self.assertEqual(appdiscovery, myns[0])

--- a/tests/test_pkgresources.py
+++ b/tests/test_pkgresources.py
@@ -24,40 +24,36 @@
 from __future__ import absolute_import
 
 from .helpers import FlaskTestCase
-from flask.ext.registry import Registry, PkgResourcesDirDiscoveryRegistry, \
-    ImportPathRegistry, EntryPointRegistry, RegistryBase
+from flask.ext.registry import (Registry, RegistryBase,
+                                PkgResourcesDirDiscoveryRegistry,
+                                ImportPathRegistry, EntryPointRegistry)
 
 
 class TestPkgResourcesDiscoveryRegistry(FlaskTestCase):
+
     def test_registration(self):
         Registry(app=self.app)
 
-        self.app.extensions['registry']['pathns'] = \
-            ImportPathRegistry(initial=['tests'])
+        self.app.extensions['registry'].update(
+            pathns=ImportPathRegistry(initial=['tests']))
+        self.app.extensions['registry'].update(
+            myns=PkgResourcesDirDiscoveryRegistry('resources',
+                                                  app=self.app,
+                                                  registry_namespace='pathns'))
 
-        self.app.extensions['registry']['myns'] = \
-            PkgResourcesDirDiscoveryRegistry(
-                'resources',
-                app=self.app,
-                registry_namespace='pathns'
-            )
-
-        assert len(self.app.extensions['registry']['myns']) == 1
+        self.assertEquals(1, len(self.app.extensions['registry']['myns']))
 
     def test_missing_folder(self):
         Registry(app=self.app)
 
-        self.app.extensions['registry']['pathns'] = \
-            ImportPathRegistry(initial=['tests'])
+        self.app.extensions['registry'].update(
+            pathns=ImportPathRegistry(initial=['tests']))
+        self.app.extensions['registry'].update(
+            myns=PkgResourcesDirDiscoveryRegistry('non_existing_folder',
+                                                  app=self.app,
+                                                  registry_namespace='pathns'))
 
-        self.app.extensions['registry']['myns'] = \
-            PkgResourcesDirDiscoveryRegistry(
-                'non_existing_folder',
-                app=self.app,
-                registry_namespace='pathns',
-            )
-
-        assert len(self.app.extensions['registry']['myns']) == 0
+        self.assertEquals(0, len(self.app.extensions['registry']['myns']))
 
 
 class TestEntryPointRegistry(FlaskTestCase):


### PR DESCRIPTION
**The problem:** this kind of code was not possible:

``` python
# registry is just like a dict.
app.extensions['registry'].update(
    pathns=ImportPathRegistry(...),
    myns=ModuleDiscoveryRegistry(...),
)
```

**Changes:**
- Properly implementing `dict` and `list`-like classes via [the collections abstract classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes).
- Flake8 :heart: 
- Refactoring of the `__init__.py` file, the classes have been moved to the `base` module.
