### PR TITLE
WIP package import that indirectly triggers importerror

### DIFF
--- a/flask_registry/registries/appdiscovery.py
+++ b/flask_registry/registries/appdiscovery.py
@@ -112,11 +112,13 @@ Each ``views`` module should define either a single blueprint in the variable
     test2
 
 """
-
 from __future__ import absolute_import
 
-from werkzeug.utils import import_string
+import sys
+
 from flask import Blueprint, Config
+from six import reraise
+from werkzeug.utils import import_string, find_modules
 
 from .core import ListRegistry, ImportPathRegistry
 from .modulediscovery import ModuleDiscoveryRegistry, \

--- a/flask_registry/registries/modulediscovery.py
+++ b/flask_registry/registries/modulediscovery.py
@@ -219,8 +219,16 @@ class ModuleDiscoveryRegistry(ModuleRegistry):
                 message     # "'module' object has no attribute 'broken_module'"
             )
         except AttributeError:
-            # No nested exception. There is an actual import issue.
-            should_reraise = True
+            message = (
+                exception.
+                exception.
+                message)
+            if '.' in self.module_name:
+                if message == 'No module named {0}'.format(self.module_name.split('.')[0]):
+                    should_reraise = False
+            else:
+                # No nested exception. There is an actual import issue.
+                should_reraise = True
         else:
             if message != "'module' object has no attribute '{0}'".format(self.module_name) or \
                     exception.import_name == import_str:  # direct attempt at importing a missing module


### PR DESCRIPTION
When overlaying inveniosoftware/invenio, bad imports of this type were silently ignored, causing the registry to be missing files.

When mitsuhiko/werkzeug#735 lands, this will also point to the correct exception.