### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,10 +1,10 @@
 Authors
 -------
 
-Flask-Registry is developed for use in `Invenio <http://invenio-software.org>`_
+Flask-Registry is developed for use in `Invenio <http://inveniosoftware.org>`_
 digital library software.
 
-Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
+Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 Contributors
 ^^^^^^^^^^^^

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -45,8 +45,8 @@ Homepage
 Good luck and thanks for choosing Flask-Registry.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: http://github.com/inveniosoftware
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,4 +1,4 @@
 Contributing
 ============
 
-See <http://invenio-software.org/wiki/Development/Contributing> for now.
+See <http://inveniosoftware.org/wiki/Development/Contributing> for now.

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     url='http://github.com/inveniosoftware/flask-registry/',
     license='BSD',
     author='Invenio collaboration',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description='Flask-Registry is an extension for Flask that allow '
         'frameworks to dynamically assemble your Flask application from '
         'reusable packages consisting of blueprints, extensions, and '


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>